### PR TITLE
cntCharsAfterLastEOF could be read without ever being initialized

### DIFF
--- a/pdfid.py
+++ b/pdfid.py
@@ -240,6 +240,7 @@ class cPDFEOF:
     def __init__(self):
         self.token = ''
         self.cntEOFs = 0
+        self.cntCharsAfterLastEOF = 0
 
     def parse(self, char):
         if self.cntEOFs > 0:


### PR DESCRIPTION
Which results in an exception