### PR TITLE
Update plugin_biff.py

### DIFF
--- a/plugin_biff.py
+++ b/plugin_biff.py
@@ -1318,7 +1318,7 @@ def ShortXLUnicodeString(data, isBIFF8):
         else:
             return repr(data[2:2 + cch * 2])
     else:
-        return P23Decode(data[1:1 + cch])
+        return P23Decode(data[2:2 + cch])
 
 def GetDictionary(passwordfile):
     if passwordfile != '.':


### PR DESCRIPTION
As a result of this commit "https://github.com/DidierStevens/DidierStevensSuite/commit/b846812b2c7bf7bdc7aa92eeb9b926f7ed937ccf" the data retrieved like sheet names starts with a null byte and ignore the last byte or character 
old output: https://ibb.co/9ZTWbsW
New output: https://ibb.co/7K0wvGK