### PR TITLE
Fix ASCIIHexDecode: convert binary input string to ascii string.

### DIFF
--- a/pdf-parser.py
+++ b/pdf-parser.py
@@ -998,7 +998,7 @@ def ASCII85Decode(data):
   return out
 
 def ASCIIHexDecode(data):
-    return binascii.unhexlify(''.join([c for c in data if c not in ' \t\n\r']).rstrip('>'))
+    return binascii.unhexlify(''.join([c for c in data.decode('ascii') if c not in ' \t\n\r']).rstrip('>'))
 
 # if inflating fails, we try to inflate byte per byte (sample 4da299d6e52bbb79c0ac00bad6a1d51d4d5fe42965a8d94e88a359e5277117e2)
 def FlateDecode(data):


### PR DESCRIPTION
Otherwise, 'not in' and 'rstrip' would fail.