### PR TITLE
Minor updates. Supporting for Power Point File embeded inside OLE file

### DIFF
--- a/plugin_ppt.py
+++ b/plugin_ppt.py
@@ -323,7 +323,7 @@ class cPPT(cPluginParent):
             0xF145: 'RT_TimeSubEffectContainer'
         }
 
-        if self.streamname == ['PowerPoint Document']:
+        if self.streamname[-1] == 'PowerPoint Document':
             self.ran = True
             stream = self.stream
 


### PR DESCRIPTION
plugin_ppt works well for Analysis a PowerPoint File.
But when PowerPoint File is embeded in another OLE file, for example .ppt embeed in a .doc. It won't display the stream details.
Becausee in this case, self.stream is an array contains muitple names reflects structure like "**ObjectPool/_1758735834/PowerPoint Document**"