### PR TITLE
raw strings for regex

### DIFF
--- a/pdf-parser.py
+++ b/pdf-parser.py
@@ -1147,7 +1147,7 @@ def PrintGenerateObject(object, options, newId=None):
         if options.filter:
             decompressed = object.Stream(True, options.overridingfilters)
             if decompressed == 'No filters' or decompressed.startswith('Unsupported filter: '):
-                print('    oPDF.stream(%d, %d, %s, %s)' % (objectId, object.version, repr(object.Stream(False, options.overridingfilters).rstrip()), repr(re.sub('/Length\s+\d+', '/Length %d', FormatOutput(dataPrecedingStream, True)).strip())))
+                print('    oPDF.stream(%d, %d, %s, %s)' % (objectId, object.version, repr(object.Stream(False, options.overridingfilters).rstrip()), repr(re.sub(r'/Length\s+\d+', '/Length %d', FormatOutput(dataPrecedingStream, True)).strip())))
             else:
                 dictionary = FormatOutput(dataPrecedingStream, True)
                 dictionary = re.sub(r'/Length\s+\d+', '', dictionary)
@@ -1158,7 +1158,7 @@ def PrintGenerateObject(object, options, newId=None):
                 dictionary = dictionary.strip()
                 print("    oPDF.stream2(%d, %d, %s, %s, 'f')" % (objectId, object.version, repr(decompressed.rstrip()), repr(dictionary)))
         else:
-            print('    oPDF.stream(%d, %d, %s, %s)' % (objectId, object.version, repr(object.Stream(False, options.overridingfilters).rstrip()), repr(re.sub('/Length\s+\d+', '/Length %d', FormatOutput(dataPrecedingStream, True)).strip())))
+            print('    oPDF.stream(%d, %d, %s, %s)' % (objectId, object.version, repr(object.Stream(False, options.overridingfilters).rstrip()), repr(re.sub(r'/Length\s+\d+', '/Length %d', FormatOutput(dataPrecedingStream, True)).strip())))
     else:
         print('    oPDF.indirectobject(%d, %d, %s)' % (objectId, object.version, repr(FormatOutput(object.content, True).strip())))
 


### PR DESCRIPTION
Without fix the python 3.12 is throwing this error: 
```
$ python3 pdf-parser.py --version
/home/mambroz/rpmbuild/BUILD/DidierStevensSuite-41b01df75c8bb332f37d2e9eb4c8279583164d0e/pdf-parser.py:1150: SyntaxWarning: invalid escape sequence '\s'
  print('    oPDF.stream(%d, %d, %s, %s)' % (objectId, object.version, repr(object.Stream(False, options.overridingfilters).rstrip()), repr(re.sub('/Length\s+\d+', '/Length %d', FormatOutput(dataPrecedingStream, True)).strip())))
/home/mambroz/rpmbuild/BUILD/DidierStevensSuite-41b01df75c8bb332f37d2e9eb4c8279583164d0e/pdf-parser.py:1161: SyntaxWarning: invalid escape sequence '\s'
  print('    oPDF.stream(%d, %d, %s, %s)' % (objectId, object.version, repr(object.Stream(False, options.overridingfilters).rstrip()), repr(re.sub('/Length\s+\d+', '/Length %d', FormatOutput(dataPrecedingStream, True)).strip())))
/home/mambroz/rpmbuild/BUILD/DidierStevensSuite-41b01df75c8bb332f37d2e9eb4c8279583164d0e/pdf-parser.py:1607: SyntaxWarning: invalid escape sequence '\d'
  if re.match('PDF-\d\.\d', comment):
This program has not been tested with this version of Python (3.12.0)
Should you encounter problems, please use Python version 3.11.1
pdf-parser.py 0.7.8

```