### PR TITLE
Fix stream indexes parsing issue as stream indexes might be separated

### DIFF
--- a/pdf-parser.py
+++ b/pdf-parser.py
@@ -1585,7 +1585,16 @@ def Main():
                 oPDFParseDictionary = cPDFParseDictionary(object.ContainsStream(), options.nocanonicalizedoutput)
                 numberOfObjects = int(oPDFParseDictionary.Get('/N')[0])
                 offsetFirstObject = int(oPDFParseDictionary.Get('/First')[0])
-                indexes = list(map(int, C2SIP3(object.Stream())[:offsetFirstObject].strip().split(' ')))
+                data_indexes = C2SIP3(object.Stream())[:offsetFirstObject].strip().split(' ')
+                # Some indexes might be associated with newline b'12 0\n10 55\n17 169\n19'
+                final_indexes = []
+                for d in data_indexes:
+                    if '\n' in d:
+                        s = d.split('\n')
+                        final_indexes.extend(s)
+                    else:
+                        final_indexes.append(d)
+                indexes = list(map(int, final_indexes))
                 if len(indexes) % 2 != 0 or len(indexes) / 2 != numberOfObjects:
                     raise Exception('Error in index of /ObjStm stream')
                 streamObject = C2SIP3(object.Stream()[offsetFirstObject:])


### PR DESCRIPTION
Stream indexes can be separate by whitespaces as well as new line, for example:

```
b'12 0\n10 55\n17 169\n19 590\n20 772\n11 778\n24 899\n26 1061\n27 1243\n2 1248\n1 1329\n5 1365\n<</Font<</F0 10 0 R/F31 11 0 R>>/XObject<</I0 7 0 R>>>><</Type/Font/Subtype/Type0/BaseFont/CDXDMY+ArialMT/Encoding/Identity-H/ToUnicode 16 0 R/DescendantFonts[ 17 0 R]>><</Type/Font/Subtype/CIDFontType2/BaseFont/CDXDMY+ArialMT/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 19 0 R/DW 750\n\n/W[1[667 556 500 833 556 556 278 278 667 556 500 222 500 722 278\n611 667 722 667 278 667 778 778 722 667 556 556 500 278 333 222\n556 556 556 556 556 500 191 722 278 278 500 667 556 556 333 556\n556 556 556 833 278 556 611 556 722 722 667 722 556 556 389]\n63 63 556\n]>><</Type/FontDescriptor/Flags 262176/Ascent 728/CapHeight 716/Descent -210/FontBBox[-665 -325 2000 1006]/FontName/CDXDMY+ArialMT/ItalicAngle 0/StemV 166/XHeight 519/FontFile2 15 0 R>>32594\n<</Type/Font/Subtype/Type0/BaseFont/KZRRCW+CourierNewPSMT/Encoding/Identity-H/ToUnicode 23 0 R/DescendantFonts[ 24 0 R]>><</Type/Font/Subtype/CIDFontType2/BaseFont/KZRRCW+CourierNewPSMT/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 26 0 R/DW 600\n>><</Type/FontDescriptor/Flags 33/Ascent 613/CapHeight 570/Descent -188/FontBBox[-593 -300 638 951]/FontName/KZRRCW+CourierNewPSMT/ItalicAngle 0/StemV 88/XHeight 405/FontFile2 22 0 R>>8834\n<</Type/Page/Parent 1 0 R/Contents 4 0 R/Resources 12 0 R/MediaBox[0 0 595 842]>><</Type/Pages/Count 1/Kids[ 2 0 R]>>[/Indexed/DeviceRGB 255 6 0 R]'
```